### PR TITLE
Fix invalid hex color in Tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,7 @@ module.exports = {
         'midnight': '#121063',
         'metal': '#565584',
         'tahiti': '#3ab7bf',
-        'silver': '#evebff',
+        'silver': '#c0c0c0',
         'bubble-gum': '#ff77e9',
         'bermuda': '#78dcca',
       },


### PR DESCRIPTION
## Summary
- fix typo in custom color palette for Tailwind

## Testing
- `npm run lint`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6840634c1650832e86fe860cab2500d2