### PR TITLE
Fix repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+"
+    "url": "git+https://github.com/maycrodriguess/basic-page-layout-react.git"
   },
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.1",


### PR DESCRIPTION
## Summary
- point repository url to the GitHub repo

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840644464d4832eb1bc13ad5005c297